### PR TITLE
Fix iframe frameborder attribute

### DIFF
--- a/article2.html
+++ b/article2.html
@@ -646,7 +646,7 @@
       <p class="large-break">Команда проекта Поток собрала 10 таких треков. Может подойдёт — особенно если сейчас ночь и ты не знаешь, за что взяться первым.</p>
       
       <div class="spotify-embed">
-        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/1SfxgcGL4FmnuPDNr2og5H?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/1SfxgcGL4FmnuPDNr2og5H?utm_source=generator" width="100%" height="352" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
       
       <p>Обычно на этом месте идёт что-то в духе «разбор каждого трека».</p>
@@ -661,7 +661,7 @@
         <div class="track-description">Трек остаётся на одной линии — как будто специально, чтобы не мешать внутренним колебаниям.</div>
         
         <div class="spotify-track">
-          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/1BWOUFGSAbPzrhZxDMno2K?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/1BWOUFGSAbPzrhZxDMno2K?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
         </div>
       </div>
 
@@ -671,7 +671,7 @@
         <div class="track-description">Работает как мягкий фон, если не хочется думать впрямую.</div>
         
         <div class="spotify-track">
-          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/4WwBiU44bdsEDxI0heabjb?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/4WwBiU44bdsEDxI0heabjb?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
         </div>
       </div>
 
@@ -682,7 +682,7 @@
         <div class="track-description">Можно слушать бесконечно — он просто создаёт текстуру.</div>
         
         <div class="spotify-track">
-          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/24QnH4LamDh2UhhmHyXjE8?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/24QnH4LamDh2UhhmHyXjE8?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
         </div>
       </div>
 
@@ -693,7 +693,7 @@
         <div class="track-description">Подходит на фоне, когда внимание расфокусировано, и хочется, чтобы что-то текло само.</div>
         
         <div class="spotify-track">
-          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/021Uxj35X52xeXHjCZEFNx?utm_source=generator&theme=0" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/021Uxj35X52xeXHjCZEFNx?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use proper lowercase `frameborder="0"` attribute for Spotify iframes in article2

## Testing
- `grep -n "frameborder=" -n article2.html`

------
https://chatgpt.com/codex/tasks/task_e_6842af6a0894832dae909ede44cb3d30